### PR TITLE
Correct Build Command

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "scripts": {
-    "build": "jekyll build && mv _site public",
+    "build": "jekyll build",
     "postcss": "postcss ./_includes/tailwind.css -o ./assets/css/site.css"
   },
   "dependencies": {


### PR DESCRIPTION
This PR removes the `&& mv _site public` portion of the build command as Vercel automatically detects Jekyll and looks in the default output folder which, in this case, has not been changed.

By removing this, the build completes successfully, the end result of which can be found here: https://vercel.com/mcsdev/michaelloistl-com/kwi1nbrco