### PR TITLE
Add cleanUrls Configuration

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "cleanUrls": true
+}


### PR DESCRIPTION
This PR adds a `vercel.json` file with the `cleanUrls: true` property. This allows the visiting of URL's with their file extension stripped.

A working example can be found here: https://michaelloistl-com.vercel.app/2020/11/26/rfa-early-access

Further information is available [here](https://vercel.com/docs/configuration#project/clean-urls).